### PR TITLE
contextless kernel through context delegation

### DIFF
--- a/aiml/InMemorySessionManager.py
+++ b/aiml/InMemorySessionManager.py
@@ -1,0 +1,41 @@
+import copy
+
+
+class InMemorySessionManager():
+
+    _inputHistory = "_inputHistory"     # keys to a queue (list) of recent user input
+    _outputHistory = "_outputHistory"   # keys to a queue (list) of recent responses.
+    _inputStack = "_inputStack"         # Should always be empty in between calls to respond()
+
+    def __init__(self):
+        self._sessions = {}
+
+    def _addSession(self, sessionID):
+        if sessionID in self._sessions:
+            return
+        # Create the session.
+        self._sessions[sessionID] = {
+            # Initialize the special reserved predicates
+            self._inputHistory: [],
+            self._outputHistory: [],
+            self._inputStack: []
+        }
+
+    def _get_session_value(self, sessionID, name):
+        return self._sessions[sessionID][name]
+
+    def _set_session_value(self, sessionID, name, value):
+        self._sessions[sessionID][name] = value
+
+    def _deleteSession(self, sessionID):
+        if sessionID in self._sessions:
+            self._sessions.pop(sessionID)
+
+    def getSessionData(self, sessionID = None):
+        s = None
+        if sessionID is not None:
+            try: s = self._sessions[sessionID]
+            except KeyError: s = {}
+        else:
+            s = self._sessions
+        return copy.deepcopy(s)

--- a/aiml/InMemorySessionManager.py
+++ b/aiml/InMemorySessionManager.py
@@ -7,19 +7,14 @@ class InMemorySessionManager():
     _outputHistory = "_outputHistory"   # keys to a queue (list) of recent responses.
     _inputStack = "_inputStack"         # Should always be empty in between calls to respond()
 
-    def __init__(self):
-        self._sessions = {}
-
     def _addSession(self, sessionID):
-        if sessionID in self._sessions:
-            return
-        # Create the session.
-        self._sessions[sessionID] = {
-            # Initialize the special reserved predicates
-            self._inputHistory: [],
-            self._outputHistory: [],
-            self._inputStack: []
-        }
+        if not sessionID in self._sessions:
+            self._sessions[sessionID] = {
+                # Initialize the special reserved predicates
+                self._inputHistory: [],
+                self._outputHistory: [],
+                self._inputStack: []
+            }
 
     def _get_session_value(self, sessionID, name):
         return self._sessions[sessionID][name]
@@ -32,10 +27,8 @@ class InMemorySessionManager():
             self._sessions.pop(sessionID)
 
     def getSessionData(self, sessionID = None):
-        s = None
-        if sessionID is not None:
-            try: s = self._sessions[sessionID]
-            except KeyError: s = {}
-        else:
-            s = self._sessions
+        s = self._sessions
+        if sessionID and sessionID in self._sessions:
+            s = self._sessions[sessionID]
+
         return copy.deepcopy(s)

--- a/aiml/Kernel.py
+++ b/aiml/Kernel.py
@@ -29,7 +29,7 @@ class Kernel:
     _outputHistory = "_outputHistory"   # keys to a queue (list) of recent responses.
     _inputStack = "_inputStack"         # Should always be empty in between calls to respond()
 
-    def __init__(self, *args, _sessionManager=InMemorySessionManager()):
+    def __init__(self, _sessionManager=InMemorySessionManager()):
         self._verboseMode = True
         self._version = "PyAIML 0.8.6"
         self._brain = PatternMgr()


### PR DESCRIPTION
Hey @eric-cc-su, I'm embedding this engine into some REST API, so I'm proposing this 
 "architectural" PR.

The aim is to move sessions out of the kernel and delegate the management to specialised classes (eg. InMemorySessionManager.py, which is the default implementation).

FYI I have successfully implemented my own, persisting the context onto DB.

Let me know what you think about it (and I'm sorry for the elegance of code, but I'm a python newbie :-) )
